### PR TITLE
Protocol: Force registry value to 1 when Enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - SChannelDsc
   - Changed the build pipeline to use the build worked image `windows-latest`.
+- Protocol
+  - Setting `State` to `Enabled` exclusively uses '1', instead of '4294967295', when assessing the associated
+    registry key value ([issue 32](https://github.com/dsccommunity/SChannelDsc/issues/32)).
 
 ## [1.4.0] - 2022-05-17
 

--- a/source/Modules/SChannelDsc.Util/SChannelDsc.Util.psm1
+++ b/source/Modules/SChannelDsc.Util/SChannelDsc.Util.psm1
@@ -202,10 +202,6 @@ function Get-SChannelItem
         {
             return 'Enabled'
         }
-        4294967295
-        {
-            return 'Enabled'
-        } # 0xffffffff
     }
 }
 
@@ -319,7 +315,7 @@ function Set-SChannelItem
             }
             else
             {
-                $null = $regKey.SetValue($ItemValue, 0xffffffff, [Microsoft.Win32.RegistryValueKind]::DWORD)
+                $null = $regKey.SetValue($ItemValue, 1, [Microsoft.Win32.RegistryValueKind]::DWORD)
             }
         }
     }

--- a/tests/Unit/SChannelDsc/SChannelDsc.Util.Tests.ps1
+++ b/tests/Unit/SChannelDsc/SChannelDsc.Util.Tests.ps1
@@ -128,7 +128,7 @@ InModuleScope $script:subModuleName {
 
         It "Setting is enabled. Should enable the specified item in this method" {
             Set-SChannelItem -ItemKey 'TestRegistry:\SCHANNEL\Protocols' -ItemSubKey 'SSL 3.0' -State 'Enabled'
-            (Get-ItemPropertyValue -Path 'TestRegistry:\SChannel\Protocols\SSL 3.0' -Name 'Enabled') | Should -Be 4294967295
+            (Get-ItemPropertyValue -Path 'TestRegistry:\SChannel\Protocols\SSL 3.0' -Name 'Enabled') | Should -Be 1
         }
 
         It "Setting is disabled. Should disable the specified item in this method" {


### PR DESCRIPTION
#### Pull Request (PR) description

- Protocol
  - Removed '4294967295' from evaluating `State` as `Enabled`
  - Registry key is now set to '1' when `State` is set to `Enabled`

#### This Pull Request (PR) fixes the following issues

- Fixes #32

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
